### PR TITLE
fix/ignore rubocop offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+---
+AllCops:
+  Excludes:
+    - compile-extensions/**
+Documentation:
+  Enabled: false
+LineLength:
+  Enabled: false
+MethodLength:
+  Max: 25
+ParameterLists:
+  Max: 12

--- a/bin/detect
+++ b/bin/detect
@@ -23,7 +23,7 @@ require 'buildpack'
 
 app_dir = ARGV[0]
 if AspNet5Buildpack.detect(app_dir)
-  puts "ASP.NET 5"
+  puts 'ASP.NET 5'
   exit 0
 else
   exit 1

--- a/bin/release
+++ b/bin/release
@@ -23,6 +23,6 @@ require 'buildpack'
 
 build_dir = ARGV[0]
 
-File.open(File.join(build_dir, "aspnet5-buildpack-release.yml")) do |f|
+File.open(File.join(build_dir, 'aspnet5-buildpack-release.yml')) do |f|
   puts f.read
 end

--- a/lib/buildpack.rb
+++ b/lib/buildpack.rb
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "./buildpack/compiler.rb"
-require_relative "./buildpack/detecter.rb"
-require_relative "./buildpack/shell.rb"
-require_relative "./buildpack/out.rb"
-require_relative "./buildpack/copier.rb"
+require_relative './buildpack/compiler.rb'
+require_relative './buildpack/detecter.rb'
+require_relative './buildpack/shell.rb'
+require_relative './buildpack/out.rb'
+require_relative './buildpack/copier.rb'
 
 module AspNet5Buildpack
   def self.detect(build_dir)
@@ -34,7 +34,7 @@ module AspNet5Buildpack
       build_dir,
       cache_dir,
       MonoInstaller.new(build_dir, shell),
-      File.expand_path("../../resources/Nowin.vNext", __FILE__),
+      File.expand_path('../../resources/Nowin.vNext', __FILE__),
       DnvmInstaller.new(shell),
       Mozroots.new(shell),
       DnxInstaller.new(shell),

--- a/lib/buildpack/compile/dnu.rb
+++ b/lib/buildpack/compile/dnu.rb
@@ -22,7 +22,8 @@ module AspNet5Buildpack
 
     def restore(dir, out)
       @shell.env['HOME'] = dir
-      @shell.exec("bash -c 'source #{dir}/.dnx/dnvm/dnvm.sh; dnvm use default -r mono -a x64; cd #{dir}; dnu restore'", out)
+      cmd = "bash -c 'source #{dir}/.dnx/dnvm/dnvm.sh; dnvm use default -r mono -a x64; cd #{dir}; dnu restore'"
+      @shell.exec(cmd, out)
     end
   end
 end

--- a/lib/buildpack/compile/dnvm_installer.rb
+++ b/lib/buildpack/compile/dnvm_installer.rb
@@ -22,7 +22,8 @@ module AspNet5Buildpack
 
     def install(dir, out)
       @shell.env['HOME'] = dir
-      @shell.exec('touch ~/.bashrc; curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=dev sh; rm -rf ~/.bashrc', out)
+      cmd = 'touch ~/.bashrc; curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=dev sh; rm -rf ~/.bashrc'
+      @shell.exec(cmd, out)
     end
   end
 end

--- a/lib/buildpack/compile/dnx_installer.rb
+++ b/lib/buildpack/compile/dnx_installer.rb
@@ -39,12 +39,10 @@ module AspNet5Buildpack
       version_file = File.expand_path(File.join(dir, DNX_VERSION_FILE_NAME))
       if File.exists?(version_file)
         begin
-          global_props = JSON.parse(File.read(version_file, :encoding => 'bom|utf-8'))
+          global_props = JSON.parse(File.read(version_file, encoding: 'bom|utf-8'))
           if global_props.has_key?('sdk')
             sdk = global_props['sdk']
-            if sdk.has_key?('version')
-              dnx_version = sdk['version']
-            end
+            dnx_version = sdk['version'] if sdk.has_key?('version')
           end
         rescue
           out.warn("File #{version_file} is not valid JSON")

--- a/lib/buildpack/compile/mono_installer.rb
+++ b/lib/buildpack/compile/mono_installer.rb
@@ -27,7 +27,8 @@ module AspNet5Buildpack
 
     def extract(dest_dir, out)
       out.print("Mono version: #{version}")
-      run_common_cmd("mkdir -p #{dest_dir}; curl -L `translate_dependency_url #{dependency_name}` -s | tar zxv -C #{dest_dir} &> /dev/null", out)
+      cmd = "mkdir -p #{dest_dir}; curl -L `translate_dependency_url #{dependency_name}` -s | tar zxv -C #{dest_dir} &> /dev/null"
+      run_common_cmd(cmd, out)
     end
 
     def version
@@ -59,7 +60,7 @@ module AspNet5Buildpack
     end
 
     def mono_version_file
-      File.join(app_dir, ".mono-version")
+      File.join(app_dir, '.mono-version')
     end
 
     private

--- a/lib/buildpack/compile/mozroots.rb
+++ b/lib/buildpack/compile/mozroots.rb
@@ -21,8 +21,8 @@ module AspNet5Buildpack
     end
 
     def import(out)
-      @shell.path << "/app/mono/bin"
-      @shell.exec("mozroots --import --sync --quiet", out)
+      @shell.path << '/app/mono/bin'
+      @shell.exec('mozroots --import --sync --quiet', out)
     end
   end
 end

--- a/lib/buildpack/compile/release_yml_writer.rb
+++ b/lib/buildpack/compile/release_yml_writer.rb
@@ -29,36 +29,36 @@ module AspNet5Buildpack
 
     def write_yml(dirs)
       unless dirs.with_existing_cfweb.empty?
-        write_yml_for(dirs.release_yml_path, dirs.with_existing_cfweb.first, "cf-web")
+        write_yml_for(dirs.release_yml_path, dirs.with_existing_cfweb.first, 'cf-web')
         return
       end
 
       unless dirs.with_project_json.empty?
         add_cfweb_command(dirs.project_json(dirs.with_project_json.first))
-        write_yml_for(dirs.release_yml_path, dirs.with_project_json.first, "cf-web")
+        write_yml_for(dirs.release_yml_path, dirs.with_project_json.first, 'cf-web')
         return
       end
 
-      write_yml_for(dirs.release_yml_path, ".", "cf-web")
+      write_yml_for(dirs.release_yml_path, '.', 'cf-web')
     end
 
     def add_cfweb_command(project_json)
-      json = JSON.parse(IO.read(project_json, :encoding => 'bom|utf-8'))
-      json["dependencies"] ||= {}
-      json["dependencies"]["Nowin.vNext"] = "1.0.0-*" unless json["dependencies"]["Nowin.vNext"]
-      json["commands"] ||= {}
-      json["commands"]["cf-web"] = "Microsoft.AspNet.Hosting --server Nowin.vNext"
+      json = JSON.parse(IO.read(project_json, encoding: 'bom|utf-8'))
+      json['dependencies'] ||= {}
+      json['dependencies']['Nowin.vNext'] = '1.0.0-*' unless json['dependencies']['Nowin.vNext']
+      json['commands'] ||= {}
+      json['commands']['cf-web'] = 'Microsoft.AspNet.Hosting --server Nowin.vNext'
       IO.write(project_json, JSON.pretty_generate(json))
     end
 
     def write_startup_script(path)
       FileUtils.mkdir_p(File.dirname(path))
       File.open(path, 'w') do |f|
-        f.write "export PATH=/app/mono/bin:$PATH;"
-        f.write "export HOME=/app;"
-        f.write "source /app/.dnx/dnvm/dnvm.sh;"
-        f.write "dnvm use default -r mono -a x64;"
-        f.write "dnu restore;"
+        f.write 'export PATH=/app/mono/bin:$PATH;'
+        f.write 'export HOME=/app;'
+        f.write 'source /app/.dnx/dnvm/dnvm.sh;'
+        f.write 'dnvm use default -r mono -a x64;'
+        f.write 'dnu restore;'
       end
     end
 
@@ -78,41 +78,41 @@ EOT
       end
 
       def release_yml_path
-        File.join(@dir, "aspnet5-buildpack-release.yml")
+        File.join(@dir, 'aspnet5-buildpack-release.yml')
       end
 
       def startup_script_path
-        File.join(@dir, ".profile.d", "startup.sh")
+        File.join(@dir, '.profile.d', 'startup.sh')
       end
 
       def with_web_commands
-        with_command("web")
+        with_command('web')
       end
 
       def with_existing_cfweb
-        with_command("cf-web")
+        with_command('cf-web')
       end
 
       def with_command(cmd)
-        with_project_json.select { |d| commands(d)[cmd] != nil && commands(d)[cmd] != "" }
+        with_project_json.select { |d| commands(d)[cmd] != nil && commands(d)[cmd] != '' }
       end
 
       def with_project_json
-        Dir.glob(File.join(@dir, "**", "project.json")).map do |d|
+        Dir.glob(File.join(@dir, '**', 'project.json')).map do |d|
           relative_path_to(File.dirname(d))
         end.reject do |d|
-          d.fnmatch?("src/Nowin.vNext")
+          d.fnmatch?('src/Nowin.vNext')
         end.sort do |d|
-          commands(d)["web"] ? 0 : 1
+          commands(d)['web'] ? 0 : 1
         end
       end
 
       def commands(dir)
-        JSON.load(IO.read(project_json(dir), :encoding => 'bom|utf-8')).fetch("commands", {})
+        JSON.load(IO.read(project_json(dir), encoding: 'bom|utf-8')).fetch('commands', {})
       end
 
       def project_json(dir)
-        File.join(@dir, dir, "project.json")
+        File.join(@dir, dir, 'project.json')
       end
 
       def relative_path_to(d)

--- a/lib/buildpack/compiler.rb
+++ b/lib/buildpack/compiler.rb
@@ -20,14 +20,14 @@ require_relative 'compile/dnvm_installer.rb'
 require_relative 'compile/dnx_installer.rb'
 require_relative 'compile/dnu.rb'
 require_relative 'compile/release_yml_writer.rb'
-require_relative "version.rb"
+require_relative 'version.rb'
 
 require 'json'
 require 'pathname'
 
 module AspNet5Buildpack
   class Compiler
-    WARNING_MESSAGE = "This is an experimental buildpack. It is not supported.   Do not expect it to work reliably. Please, do not         contact support about issues with this buildpack.".freeze
+    WARNING_MESSAGE = 'This is an experimental buildpack. It is not supported.   Do not expect it to work reliably. Please, do not         contact support about issues with this buildpack.'.freeze
 
     def initialize(build_dir, cache_dir, mono_binary, nowin_dir, dnvm_installer, mozroots, dnx_installer, dnu, release_yml_writer, copier, out)
       @build_dir = build_dir
@@ -47,35 +47,35 @@ module AspNet5Buildpack
       puts "ASP.NET 5 buildpack version: #{BuildpackVersion.new.version}\n"
       puts "ASP.NET 5 buildpack starting compile\n"
       out.warn(WARNING_MESSAGE) unless WARNING_MESSAGE.nil?
-      step("Restoring files from buildpack cache" , method(:restore_cache))
-      step("Extracting mono", method(:extract_mono))
-      step("Adding Nowin.vNext", method(:copy_nowin))
-      step("Importing Mozilla Root Certificates", method(:install_mozroot_certs))
-      step("Installing DNVM", method(:install_dnvm))
-      step("Installing DNX with DNVM", method(:install_dnx))
-      step("Restoring dependencies with DNU", method(:restore_dependencies))
-      step("Moving files in to place", method(:move_to_app_dir))
-      step("Saving to buildpack cache", method(:save_cache))
-      step("Writing Release YML", method(:write_release_yml))
+      step('Restoring files from buildpack cache' , method(:restore_cache))
+      step('Extracting mono', method(:extract_mono))
+      step('Adding Nowin.vNext', method(:copy_nowin))
+      step('Importing Mozilla Root Certificates', method(:install_mozroot_certs))
+      step('Installing DNVM', method(:install_dnvm))
+      step('Installing DNX with DNVM', method(:install_dnx))
+      step('Restoring dependencies with DNU', method(:restore_dependencies))
+      step('Moving files in to place', method(:move_to_app_dir))
+      step('Saving to buildpack cache', method(:save_cache))
+      step('Writing Release YML', method(:write_release_yml))
       puts "ASP.NET 5 buildpack is done creating the droplet\n"
       return true
     rescue StepFailedError => e
       out.fail(e.message)
       puts ".\n"
       out.warn(WARNING_MESSAGE)
-      sleep 2 # otherwise the warning message gets lost and you have to do logs --recent to see it
+      sleep 2 # otherwise the warning message gets lost and you have to do logs --recent to see it
       return false
     end
 
     private
 
     def extract_mono(out)
-      mono_binary.extract(File.join("/", "app"), out) unless File.exist? File.join("/app", "mono")
+      mono_binary.extract(File.join('/', 'app'), out) unless File.exist? File.join('/app', 'mono')
     end
 
     def copy_nowin(out)
-      dest_dir = File.join(build_dir, "src")
-      copier.cp(nowin_dir, dest_dir, out) unless File.exist? File.join(dest_dir, "Nowin.vNext")
+      dest_dir = File.join(build_dir, 'src')
+      copier.cp(nowin_dir, dest_dir, out) unless File.exist? File.join(dest_dir, 'Nowin.vNext')
     end
 
     def install_mozroot_certs(out)
@@ -83,8 +83,8 @@ module AspNet5Buildpack
     end
 
     def restore_cache(out)
-      copier.cp(File.join(cache_dir, ".dnx"), build_dir, out) if File.exist? File.join(cache_dir, ".dnx")
-      copier.cp(File.join(cache_dir, "mono"), File.join("/", "app"), out) if File.exist? File.join(cache_dir, "mono")
+      copier.cp(File.join(cache_dir, '.dnx'), build_dir, out) if File.exist? File.join(cache_dir, '.dnx')
+      copier.cp(File.join(cache_dir, 'mono'), File.join('/', 'app'), out) if File.exist? File.join(cache_dir, 'mono')
     end
 
     def install_dnvm(out)
@@ -100,12 +100,12 @@ module AspNet5Buildpack
     end
 
     def move_to_app_dir(out)
-      copier.cp(File.join("/app", "mono"), build_dir, out)
+      copier.cp(File.join('/app', 'mono'), build_dir, out)
     end
 
     def save_cache(out)
-      copier.cp(File.join(build_dir, ".dnx"), cache_dir, out)
-      copier.cp(File.join("/app", "mono"), cache_dir, out) unless File.exists? File.join(cache_dir, "mono")
+      copier.cp(File.join(build_dir, '.dnx'), cache_dir, out)
+      copier.cp(File.join('/app', 'mono'), cache_dir, out) unless File.exists? File.join(cache_dir, 'mono')
     end
 
     def write_release_yml(out)

--- a/lib/buildpack/copier.rb
+++ b/lib/buildpack/copier.rb
@@ -28,8 +28,9 @@ module AspNet5Buildpack
     end
 
     private
+
     def files_in_dest(dest)
-      Dir.glob( "#{dest}/**/*", File::FNM_DOTMATCH ).select do |f|
+      Dir.glob("#{dest}/**/*", File::FNM_DOTMATCH).select do |f|
         File.basename(f).gsub('.', '') != ''
       end
     end

--- a/lib/buildpack/detecter.rb
+++ b/lib/buildpack/detecter.rb
@@ -23,7 +23,7 @@ module AspNet5Buildpack
     private
 
     def can_handle?(dir)
-      File.exist? File.join(dir, "NuGet.Config")
+      File.exist? File.join(dir, 'NuGet.Config')
     end
   end
 end

--- a/lib/buildpack/out.rb
+++ b/lib/buildpack/out.rb
@@ -16,7 +16,7 @@
 
 module AspNet5Buildpack
   class Out
-    def initialize(description=nil)
+    def initialize(description = nil)
       puts "-----> #{description}\n" unless description.nil?
     end
 
@@ -45,10 +45,10 @@ module AspNet5Buildpack
     def to_warning(message)
       buff = "\n"
       buff += "  #{'*' * 72}\n"
-      prefix = "WARNING:"
+      prefix = 'WARNING:'
       message.scan(/.{1,58}/).each do |line|
-        buff += "  * #{prefix} #{line}#{' '*(60 - line.length)}*\n"
-        prefix = "        " if prefix == "WARNING:"
+        buff += "  * #{prefix} #{line}#{' ' * (60 - line.length)}*\n"
+        prefix = '        ' if prefix == 'WARNING:'
       end
       buff += "  #{'*' * 72}\n.\n"
     end

--- a/lib/buildpack/shell.rb
+++ b/lib/buildpack/shell.rb
@@ -19,7 +19,7 @@ require 'open3'
 module AspNet5Buildpack
   class Shell
     def exec(cmd, out)
-      Open3.popen2e(expand(cmd)) do |i,oe,t|
+      Open3.popen2e(expand(cmd)) do |i, oe, t|
         oe.each do |line|
           out.print line.chomp
         end
@@ -37,8 +37,9 @@ module AspNet5Buildpack
     end
 
     private
+
     def expand(cmd)
-      (exports + [cmd]).join(";")
+      (exports + [cmd]).join(';')
     end
 
     def exports

--- a/spec/buildpack/compile/compile_spec.rb
+++ b/spec/buildpack/compile/compile_spec.rb
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require "tmpdir"
-require "fileutils"
-require_relative "../../../lib/buildpack.rb"
+require 'rspec'
+require 'tmpdir'
+require 'fileutils'
+require_relative '../../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::Compiler do
   subject(:compiler) do
-    AspNet5Buildpack::Compiler.new(buildDir, cacheDir, mono_binary, nowinDir, dnvm_installer, mozroots, dnx_installer, dnu, release_yml_writer, copier, out)
+    AspNet5Buildpack::Compiler.new(build_dir, cache_dir, mono_binary, nowin_dir, dnvm_installer, mozroots, dnx_installer, dnu, release_yml_writer, copier, out)
   end
 
   before do
@@ -29,92 +29,92 @@ describe AspNet5Buildpack::Compiler do
   end
 
   let(:mono_binary) do
-    double(:mono_binary, :extract => nil)
+    double(:mono_binary, extract: nil)
   end
 
   let(:copier) do
-    double(:copier, :cp => nil)
+    double(:copier, cp: nil)
   end
 
   let(:dnvm_installer) do
-    double(:dnvm_installer, :install => nil)
+    double(:dnvm_installer, install: nil)
   end
 
   let(:dnx_installer) do
-    double(:dnx_installer, :install => nil)
+    double(:dnx_installer, install: nil)
   end
 
   let(:dnu) do
-    double(:dnu, :restore => nil)
+    double(:dnu, restore:  nil)
   end
 
   let(:mozroots) do
-    double(:mozroots, :import => nil)
+    double(:mozroots, import: nil)
   end
 
   let(:release_yml_writer) do
-    double(:release_yml_writer, :write_release_yml => nil)
+    double(:release_yml_writer, write_release_yml: nil)
   end
 
   let(:out) do
-    double(:out, :step => double(:unknown_step, :succeed => nil)).tap do |out|
+    double(:out, step: double(:unknown_step, succeed: nil)).tap do |out|
       allow(out).to receive(:warn)
     end
   end
 
-  let(:buildDir) do
+  let(:build_dir) do
     Dir.mktmpdir
   end
 
-  let(:cacheDir) do
+  let(:cache_dir) do
     Dir.mktmpdir
   end
 
-  let(:nowinDir) do
+  let(:nowin_dir) do
     Dir.mktmpdir
   end
 
-  it "prints a big warning message" do
-    expect(out).to receive(:warn).with(match("experimental"))
+  it 'prints a big warning message' do
+    expect(out).to receive(:warn).with(match('experimental'))
     compiler.compile
   end
 
-  shared_examples "A Step" do |expected_message, step, next_step|
+  shared_examples 'A Step' do |expected_message, step, next_step|
     let(:step_out) do
-      double(:step_out, :succeed => nil).tap do |step_out|
+      double(:step_out, succeed: nil).tap do |step_out|
         allow(out).to receive(:step).with(expected_message).and_return step_out
       end
     end
 
-    it "outputs the step name" do
+    it 'outputs the step name' do
       expect(out).to receive(:step).with(expected_message)
       compiler.compile
     end
 
-    context "when it succeeds" do
-      it "causes the step to succeed" do
+    context 'when it succeeds' do
+      it 'causes the step to succeed' do
         expect(step_out).to receive(:succeed)
         compiler.compile
       end
     end
 
-    context "when it fails" do
+    context 'when it fails' do
       before do
-        allow(subject).to receive(step).and_raise "fishfinger in the warp core"
+        allow(subject).to receive(step).and_raise 'fishfinger in the warp core'
         allow(out).to receive(:fail)
         allow(step_out).to receive(:fail)
         allow(out).to receive(:warn)
       end
 
-      it "prints a helpful error" do
+      it 'prints a helpful error' do
         expect(step_out).to receive(:fail).with(match(/fishfinger in the warp core/))
         expect(out).to receive(:fail).with(match(/#{expected_message} failed, fishfinger in the warp core/))
-        expect(out).to receive(:warn).with(match("experimental"))
+        expect(out).to receive(:warn).with(match('experimental'))
         expect { compiler.compile }.not_to raise_error
       end
 
       if next_step
-        it "does not run further steps" do
+        it 'does not run further steps' do
           expect(subject).not_to receive(next_step)
           compiler.compile
         end
@@ -122,117 +122,117 @@ describe AspNet5Buildpack::Compiler do
     end
   end
 
-  describe "Steps" do
-    describe "Extracting Mono" do
-      it_behaves_like "A Step", "Extracting mono", :extract_mono, :install_mozroot_certs
+  describe 'Steps' do
+    describe 'Extracting Mono' do
+      it_behaves_like 'A Step', 'Extracting mono', :extract_mono, :install_mozroot_certs
 
-      it "extracts to /app" do
-        expect(mono_binary).to receive(:extract).with("/app", anything)
+      it 'extracts to /app' do
+        expect(mono_binary).to receive(:extract).with('/app', anything)
         compiler.compile
       end
 
-      context "when mono is already extracted because it was cached" do
-        it "copies only .dnx to cache dir" do
+      context 'when mono is already extracted because it was cached' do
+        it 'copies only .dnx to cache dir' do
           allow(File).to receive(:exist?).and_return(true)
-          expect(mono_binary).not_to receive(:extract).with("/app", anything)
+          expect(mono_binary).not_to receive(:extract).with('/app', anything)
           compiler.compile
         end
       end
     end
 
-    describe "Adding Nowin.vNext" do
-      it_behaves_like "A Step", "Adding Nowin.vNext", :copy_nowin, :install_mozroot_certs
+    describe 'Adding Nowin.vNext' do
+      it_behaves_like 'A Step', 'Adding Nowin.vNext', :copy_nowin, :install_mozroot_certs
 
-      it "extracts to build dir" do
-        expect(copier).to receive(:cp).with(nowinDir, "#{buildDir}/src", anything)
+      it 'extracts to build dir' do
+        expect(copier).to receive(:cp).with(nowin_dir, "#{build_dir}/src", anything)
         compiler.compile
       end
     end
 
-    describe "Importing Certificates" do
-      it_behaves_like "A Step", "Importing Mozilla Root Certificates", :install_mozroot_certs, :install_dnvm
+    describe 'Importing Certificates' do
+      it_behaves_like 'A Step', 'Importing Mozilla Root Certificates', :install_mozroot_certs, :install_dnvm
 
-      it "imports the certificates" do
+      it 'imports the certificates' do
         expect(mozroots).to receive(:import)
         compiler.compile
       end
     end
 
-    describe "Installing DNVM" do
-      it_behaves_like "A Step", "Installing DNVM", :install_dnvm, :install_dnx
+    describe 'Installing DNVM' do
+      it_behaves_like 'A Step', 'Installing DNVM', :install_dnvm, :install_dnx
 
-      it "installs dnvm" do
-        expect(dnvm_installer).to receive(:install).with(buildDir, anything)
+      it 'installs dnvm' do
+        expect(dnvm_installer).to receive(:install).with(build_dir, anything)
         compiler.compile
       end
     end
 
-    describe "Restoring Cache" do
-      it_behaves_like "A Step", "Restoring files from buildpack cache", :restore_cache, :install_dnvm
+    describe 'Restoring Cache' do
+      it_behaves_like 'A Step', 'Restoring files from buildpack cache', :restore_cache, :install_dnvm
 
-      context "when the cache does not exist" do
-        it "does not try copying" do
-          expect(copier).not_to receive(:cp).with(match(cacheDir), anything, anything)
+      context 'when the cache does not exist' do
+        it 'does not try copying' do
+          expect(copier).not_to receive(:cp).with(match(cache_dir), anything, anything)
           compiler.compile
         end
       end
 
-      context "when the cache exists" do
+      context 'when the cache exists' do
         before(:each) do
-          Dir.mkdir(File.join(cacheDir, ".dnx"))
-          Dir.mkdir(File.join(cacheDir, "mono"))
+          Dir.mkdir(File.join(cache_dir, '.dnx'))
+          Dir.mkdir(File.join(cache_dir, 'mono'))
         end
 
-        it "restores all files from the cache to build dir" do
-          expect(copier).to receive(:cp).with(File.join(cacheDir, ".dnx"), buildDir, anything)
-          expect(copier).to receive(:cp).with(File.join(cacheDir, "mono"), "/app", anything)
+        it 'restores all files from the cache to build dir' do
+          expect(copier).to receive(:cp).with(File.join(cache_dir, '.dnx'), build_dir, anything)
+          expect(copier).to receive(:cp).with(File.join(cache_dir, 'mono'), '/app', anything)
           compiler.compile
         end
       end
     end
 
-    describe "Installing DNX with DNVM" do
-      it_behaves_like "A Step", "Installing DNX with DNVM", :install_dnx, :restore_dependencies
+    describe 'Installing DNX with DNVM' do
+      it_behaves_like 'A Step', 'Installing DNX with DNVM', :install_dnx, :restore_dependencies
 
-      it "installs dnx" do
-        expect(dnx_installer).to receive(:install).with(buildDir, anything)
+      it 'installs dnx' do
+        expect(dnx_installer).to receive(:install).with(build_dir, anything)
         compiler.compile
       end
     end
 
-    describe "Moving files in to place" do
-      it_behaves_like "A Step", "Moving files in to place", :move_to_app_dir, :save_cache
+    describe 'Moving files in to place' do
+      it_behaves_like 'A Step', 'Moving files in to place', :move_to_app_dir, :save_cache
 
-      it "copies mono to build dir" do
-        expect(copier).to receive(:cp).with("/app/mono", buildDir, anything)
+      it 'copies mono to build dir' do
+        expect(copier).to receive(:cp).with('/app/mono', build_dir, anything)
         compiler.compile
       end
     end
 
-    describe "Saving to buildpack cache" do
-      it_behaves_like "A Step", "Saving to buildpack cache", :save_cache, :write_release_yml
+    describe 'Saving to buildpack cache' do
+      it_behaves_like 'A Step', 'Saving to buildpack cache', :save_cache, :write_release_yml
 
-      it "copies .dnx and mono to cache dir" do
-        expect(copier).to receive(:cp).with("#{buildDir}/.dnx", cacheDir, anything)
-        expect(copier).to receive(:cp).with("/app/mono", cacheDir, anything)
+      it 'copies .dnx and mono to cache dir' do
+        expect(copier).to receive(:cp).with("#{build_dir}/.dnx", cache_dir, anything)
+        expect(copier).to receive(:cp).with('/app/mono', cache_dir, anything)
         compiler.compile
       end
 
-      context "when mono is already cached" do
+      context 'when mono is already cached' do
         before(:each) do
-          Dir.mkdir(File.join(cacheDir, "mono"))
+          Dir.mkdir(File.join(cache_dir, 'mono'))
         end
-        it "copies only .dnx to cache dir" do
-          expect(copier).to receive(:cp).with("#{buildDir}/.dnx", cacheDir, anything)
+        it 'copies only .dnx to cache dir' do
+          expect(copier).to receive(:cp).with("#{build_dir}/.dnx", cache_dir, anything)
           compiler.compile
         end
       end
     end
 
-    describe "Writing Release YML" do
-      it_behaves_like "A Step", "Writing Release YML", :write_release_yml, nil
+    describe 'Writing Release YML' do
+      it_behaves_like 'A Step', 'Writing Release YML', :write_release_yml, nil
 
-      it "writes release yml" do
+      it 'writes release yml' do
         expect(release_yml_writer).to receive(:write_release_yml)
         compiler.compile
       end

--- a/spec/buildpack/compile/dnu_spec.rb
+++ b/spec/buildpack/compile/dnu_spec.rb
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require_relative "../../../lib/buildpack.rb"
+require 'rspec'
+require_relative '../../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::DNU do
   let(:shell) do
-    double(:shell, :env => {})
+    double(:shell, env: {})
   end
 
   let(:out) do
@@ -30,28 +30,28 @@ describe AspNet5Buildpack::DNU do
     AspNet5Buildpack::DNU.new(shell)
   end
 
-  it "sets HOME env variable to build dir so that packages are stored in /app/.dnx" do
+  it 'sets HOME env variable to build dir so that packages are stored in /app/.dnx' do
     allow(shell).to receive(:exec)
-    dnu.restore("app-dir", out)
+    dnu.restore('app-dir', out)
 
-    expect(shell.env).to include("HOME" => "app-dir")
+    expect(shell.env).to include('HOME' => 'app-dir')
   end
 
-  it "adds dnu to the PATH" do
+  it 'adds dnu to the PATH' do
     allow(shell).to receive(:exec)
-    expect(shell).to receive(:exec).with(match("dnvm use default"), out)
-    dnu.restore("app-dir", out)
+    expect(shell).to receive(:exec).with(match('dnvm use default'), out)
+    dnu.restore('app-dir', out)
   end
 
-  it "sources dnvm.sh script" do
+  it 'sources dnvm.sh script' do
     allow(shell).to receive(:exec)
-    expect(shell).to receive(:exec).with(match("source app-dir/.dnx/dnvm/dnvm.sh"), out)
-    dnu.restore("app-dir", out)
+    expect(shell).to receive(:exec).with(match('source app-dir/.dnx/dnvm/dnvm.sh'), out)
+    dnu.restore('app-dir', out)
   end
 
-  it "restores dependencies with dnu" do
+  it 'restores dependencies with dnu' do
     allow(shell).to receive(:exec)
-    expect(shell).to receive(:exec).with(match("dnu restore"), out)
-    dnu.restore("app-dir", out)
+    expect(shell).to receive(:exec).with(match('dnu restore'), out)
+    dnu.restore('app-dir', out)
   end
 end

--- a/spec/buildpack/compile/dnvm_installer_spec.rb
+++ b/spec/buildpack/compile/dnvm_installer_spec.rb
@@ -19,7 +19,7 @@ require_relative '../../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::DnvmInstaller do
   let(:shell) do
-    double(:shell, :env => {})
+    double(:shell, env: {})
   end
 
   let(:out) do
@@ -36,7 +36,8 @@ describe AspNet5Buildpack::DnvmInstaller do
   end
 
   it 'runs the dnvm web installer' do
-    expect(shell).to receive(:exec).with(match('curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=dev sh'), out)
+    cmd = 'curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=dev sh'
+    expect(shell).to receive(:exec).with(match(cmd), out)
     installer.install('passed-directory', out)
   end
 

--- a/spec/buildpack/compile/dnx_install_spec.rb
+++ b/spec/buildpack/compile/dnx_install_spec.rb
@@ -20,7 +20,7 @@ require_relative '../../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::DnxInstaller do
   let(:shell) do
-    double(:shell, :env => {})
+    double(:shell, env: {})
   end
 
   let(:out) do

--- a/spec/buildpack/compile/mono_installer_spec.rb
+++ b/spec/buildpack/compile/mono_installer_spec.rb
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require "tmpdir"
-require "tempfile"
-require_relative "../../../lib/buildpack.rb"
-require_relative "../../../lib/buildpack/shell.rb"
+require 'rspec'
+require 'tmpdir'
+require 'tempfile'
+require_relative '../../../lib/buildpack.rb'
+require_relative '../../../lib/buildpack/shell.rb'
 
 describe AspNet5Buildpack::MonoInstaller do
 
@@ -38,31 +38,31 @@ describe AspNet5Buildpack::MonoInstaller do
     described_class.new(dir, shell)
   end
 
-  describe "mono version" do
-    context "when no version is specified" do
-      it "uses default version" do
+  describe 'mono version' do
+    context 'when no version is specified' do
+      it 'uses default version' do
         expect(subject.version).to eq('4.0.1')
       end
     end
 
-    context "when a version is specified in the .mono-version file" do
+    context 'when a version is specified in the .mono-version file' do
       before do
-        IO.write(File.join(dir, ".mono-version"), "1.2.3")
+        IO.write(File.join(dir, '.mono-version'), '1.2.3')
       end
 
-      it "uses requested version" do
+      it 'uses requested version' do
         expect(subject.version).to eq('1.2.3')
       end
     end
   end
 
-  describe "mono file location" do
-    context "when present in dependencies dir" do
-      it "extracts the local binary" do
+  describe 'mono file location' do
+    context 'when present in dependencies dir' do
+      it 'extracts the local binary' do
         begin
           dependencies = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'dependencies'))
           FileUtils.mkdir_p dependencies
-          expect(out).to receive(:print).with(/file:\/\/\//)
+          expect(out).to receive(:print).with(%r{file:///})
           subject.mono_tar_gz(out)
         ensure
           FileUtils.rm_rf(dependencies) if File.exists? dependencies
@@ -70,28 +70,27 @@ describe AspNet5Buildpack::MonoInstaller do
       end
     end
 
-    context "when not present in dependencies dir" do
-      it "downloads and extracts the binary" do
-        expect(out).to receive(:print).with(/https:\/\//)
+    context 'when not present in dependencies dir' do
+      it 'downloads and extracts the binary' do
+        expect(out).to receive(:print).with(%r{https://})
         subject.mono_tar_gz(out)
       end
     end
 
-    context "when mono version is invalid" do
+    context 'when mono version is invalid' do
       before do
-        IO.write(File.join(dir, ".mono-version"), "1.2.3")
-        
+        IO.write(File.join(dir, '.mono-version'), '1.2.3')
       end
 
-      it "returns an error" do
+      it 'returns an error' do
         expect(out).to receive(:print).with(/DEPENDENCY_MISSING_IN_MANIFEST/)
         expect { subject.mono_tar_gz(out) }.to raise_error
       end
     end
   end
 
-  describe "mono extraction" do
-    it "uses compile-extensions" do
+  describe 'mono extraction' do
+    it 'uses compile-extensions' do
       allow(shell).to receive(:exec).and_return(0)
       expect(shell).to receive(:exec) do |*args|
         cmd = args.first
@@ -100,7 +99,7 @@ describe AspNet5Buildpack::MonoInstaller do
         expect(cmd).to match(/tar/)
       end
       expect(out).to receive(:print).with(/Mono version/)
-      subject.extract(dir, out)    
+      subject.extract(dir, out)
     end
   end
 

--- a/spec/buildpack/compile/mozroots_spec.rb
+++ b/spec/buildpack/compile/mozroots_spec.rb
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require_relative "../../../lib/buildpack.rb"
+require 'rspec'
+require_relative '../../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::Mozroots do
   let(:shell) do
-    double(:shell, :path => [])
+    double(:shell, path: [])
   end
 
   let(:out) do
@@ -30,15 +30,15 @@ describe AspNet5Buildpack::Mozroots do
     AspNet5Buildpack::Mozroots.new(shell)
   end
 
-  it "runs the mozroots import binary" do
-    expect(shell).to receive(:exec).with("mozroots --import --sync --quiet", out)
+  it 'runs the mozroots import binary' do
+    expect(shell).to receive(:exec).with('mozroots --import --sync --quiet', out)
     mozroots.import(out)
   end
 
-  it "adds /app/mono/bin to the path" do
+  it 'adds /app/mono/bin to the path' do
     allow(shell).to receive(:exec)
     mozroots.import(out)
 
-    expect(shell.path).to include("/app/mono/bin")
+    expect(shell.path).to include('/app/mono/bin')
   end
 end

--- a/spec/buildpack/compile/release_yml_writer_spec.rb
+++ b/spec/buildpack/compile/release_yml_writer_spec.rb
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require "yaml"
-require "tmpdir"
-require "fileutils"
-require_relative "../../../lib/buildpack.rb"
+require 'rspec'
+require 'yaml'
+require 'tmpdir'
+require 'fileutils'
+require_relative '../../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::ReleaseYmlWriter do
-  let(:buildDir) do
+  let(:build_dir) do
     Dir.mktmpdir
   end
 
@@ -29,245 +29,245 @@ describe AspNet5Buildpack::ReleaseYmlWriter do
     double(:out)
   end
 
-  describe "the release yml" do
+  describe 'the release yml' do
     let(:yml_path) do
-      File.join(buildDir, "aspnet5-buildpack-release.yml")
+      File.join(build_dir, 'aspnet5-buildpack-release.yml')
     end
 
     let(:yml) do
-      subject.write_release_yml(buildDir, out)
+      subject.write_release_yml(build_dir, out)
       YAML.load_file(yml_path)
     end
 
     let(:profile_d_script) do
-      subject.write_release_yml(buildDir, out)
-      IO.read(File.join(buildDir, ".profile.d", "startup.sh"))
+      subject.write_release_yml(build_dir, out)
+      IO.read(File.join(build_dir, '.profile.d', 'startup.sh'))
     end
 
-    describe "the .profile.d script" do
+    describe 'the .profile.d script' do
       let(:web_dir) do
-        File.join(buildDir, "foo").tap { |f| Dir.mkdir(f) }
+        File.join(build_dir, 'foo').tap { |f| Dir.mkdir(f) }
       end
 
-      it "should add /app/mono/bin to the PATH" do
-        expect(profile_d_script).to include("export PATH=/app/mono/bin:$PATH;")
+      it 'should add /app/mono/bin to the PATH' do
+        expect(profile_d_script).to include('export PATH=/app/mono/bin:$PATH;')
       end
 
-      it "should set HOME to /app (so that dependencies are picked up from /app/.dnx)" do
-        expect(profile_d_script).to include("export HOME=/app")
+      it 'should set HOME to /app (so that dependencies are picked up from /app/.dnx)' do
+        expect(profile_d_script).to include('export HOME=/app')
       end
 
-      it "should source dnvm script" do
-        expect(profile_d_script).to include("source /app/.dnx/dnvm/dnvm.sh")
+      it 'should source dnvm script' do
+        expect(profile_d_script).to include('source /app/.dnx/dnvm/dnvm.sh')
       end
 
-      it "should add the runtime to the PATH" do
-        expect(profile_d_script).to include("dnvm use default")
+      it 'should add the runtime to the PATH' do
+        expect(profile_d_script).to include('dnvm use default')
       end
 
-      it "should re-run package restore" do
-        expect(profile_d_script).to include("dnu restore")
+      it 'should re-run package restore' do
+        expect(profile_d_script).to include('dnu restore')
       end
     end
 
-    describe "the web process type" do
+    describe 'the web process type' do
       let(:web_process) do
-        yml.fetch("default_process_types").fetch("web")
+        yml.fetch('default_process_types').fetch('web')
       end
 
-      context "when there are no directories containing a project.json" do
-        it "should work (the user might be using a custom start command)" do
+      context 'when there are no directories containing a project.json' do
+        it 'should work (the user might be using a custom start command)' do
           expect(out).not_to receive(:fail)
-          subject.write_release_yml(buildDir, out)
+          subject.write_release_yml(build_dir, out)
           expect(File).to exist(yml_path)
         end
       end
 
-      context "when there is a directory with a project.json file containing a BOM" do
+      context 'when there is a directory with a project.json file containing a BOM' do
         let(:web_dir) do
-          File.join(buildDir, "foo").tap { |f| Dir.mkdir(f) }
+          File.join(build_dir, 'foo').tap { |f| Dir.mkdir(f) }
         end
 
         let(:project_json) do
-          "{}"
+          '{}'
         end
 
         before do
-          File.open(File.join(web_dir, "project.json"), 'w') do |f|
+          File.open(File.join(web_dir, 'project.json'), 'w') do |f|
             f.write "\uFEFF"
             f.write project_json
           end
         end
 
-        it "writes a release yml" do
-          subject.write_release_yml(buildDir, out)
-          expect(File).to exist(File.join(buildDir, "aspnet5-buildpack-release.yml"))
+        it 'writes a release yml' do
+          subject.write_release_yml(build_dir, out)
+          expect(File).to exist(File.join(build_dir, 'aspnet5-buildpack-release.yml'))
         end
       end
 
-      context "when there is a directory with a project.json file" do
+      context 'when there is a directory with a project.json file' do
         let(:web_dir) do
-          File.join(buildDir, "foo").tap { |f| Dir.mkdir(f) }
+          File.join(build_dir, 'foo').tap { |f| Dir.mkdir(f) }
         end
 
         let(:project_json) do
-          "{}"
+          '{}'
         end
 
         before do
-          File.open(File.join(web_dir, "project.json"), 'w') do |f|
+          File.open(File.join(web_dir, 'project.json'), 'w') do |f|
             f.write project_json
           end
         end
 
-        it "writes a release yml" do
-          subject.write_release_yml(buildDir, out)
-          expect(File).to exist(File.join(buildDir, "aspnet5-buildpack-release.yml"))
+        it 'writes a release yml' do
+          subject.write_release_yml(build_dir, out)
+          expect(File).to exist(File.join(build_dir, 'aspnet5-buildpack-release.yml'))
         end
 
-        it "contains a web process type" do
-          expect(yml).to have_key("default_process_types")
-          expect(yml.fetch("default_process_types")).to have_key("web")
+        it 'contains a web process type' do
+          expect(yml).to have_key('default_process_types')
+          expect(yml.fetch('default_process_types')).to have_key('web')
         end
 
-        it "does not contain any exports (these should be done via .profile.d script)" do
-          expect(yml).to have_key("default_process_types")
-          expect(yml["default_process_types"]["web"]).not_to include("export")
+        it 'does not contain any exports (these should be done via .profile.d script)' do
+          expect(yml).to have_key('default_process_types')
+          expect(yml['default_process_types']['web']).not_to include('export')
         end
 
-        context "and the project.json contains a cf-web command" do
+        context 'and the project.json contains a cf-web command' do
           let(:project_json) do
             '{"commands": {"cf-web": "whatever"}}'
           end
 
-          it "changes directory to that directory" do
-            expect(web_process).to match("cd foo;")
+          it 'changes directory to that directory' do
+            expect(web_process).to match('cd foo;')
           end
 
           it "runs 'dnx . cf-web'" do
-            expect(web_process).to match("dnx . cf-web")
+            expect(web_process).to match('dnx . cf-web')
           end
 
-          context "and if the cf-web command is empty" do
+          context 'and if the cf-web command is empty' do
             let(:project_json) do
               '{"commands": {"cf-web": ""}}'
             end
 
-            it "sets it to serve NoWin.vNext" do
-              subject.write_release_yml(buildDir, out)
+            it 'sets it to serve NoWin.vNext' do
+              subject.write_release_yml(build_dir, out)
 
-              json = JSON.parse(IO.read(File.join(web_dir, "project.json")))
-              expect(json["commands"]["cf-web"]).to match("Microsoft.AspNet.Hosting --server Nowin.vNext")
+              json = JSON.parse(IO.read(File.join(web_dir, 'project.json')))
+              expect(json['commands']['cf-web']).to match('Microsoft.AspNet.Hosting --server Nowin.vNext')
             end
           end
         end
 
-        context "and the project.json does not contain a cf-web command" do
-          it "adds cf-web command to project.json" do
-            subject.write_release_yml(buildDir, out)
+        context 'and the project.json does not contain a cf-web command' do
+          it 'adds cf-web command to project.json' do
+            subject.write_release_yml(build_dir, out)
 
-            json = JSON.parse(IO.read(File.join(web_dir, "project.json")))
-            expect(json).to have_key("commands")
-            expect(json["commands"]).to have_key("cf-web")
-            expect(json["commands"]["cf-web"]).to match("Microsoft.AspNet.Hosting --server Nowin.vNext")
+            json = JSON.parse(IO.read(File.join(web_dir, 'project.json')))
+            expect(json).to have_key('commands')
+            expect(json['commands']).to have_key('cf-web')
+            expect(json['commands']['cf-web']).to match('Microsoft.AspNet.Hosting --server Nowin.vNext')
           end
 
-          context "when Nowin.vNext dependency exists" do
+          context 'when Nowin.vNext dependency exists' do
             let(:project_json) do
               '{ "dependencies" : { "Nowin.vNext" : "345" } }'
             end
 
-            it "leaves it alone" do
-              subject.write_release_yml(buildDir, out)
+            it 'leaves it alone' do
+              subject.write_release_yml(build_dir, out)
 
-              json = JSON.parse(IO.read(File.join(web_dir, "project.json")))
-              expect(json["dependencies"]["Nowin.vNext"]).to match("345")
+              json = JSON.parse(IO.read(File.join(web_dir, 'project.json')))
+              expect(json['dependencies']['Nowin.vNext']).to match('345')
             end
           end
 
-          context "when Nowin.vNext dependency does not exist" do
-            it "adds Nowin.vNext dependency to project.json" do
-              subject.write_release_yml(buildDir, out)
+          context 'when Nowin.vNext dependency does not exist' do
+            it 'adds Nowin.vNext dependency to project.json' do
+              subject.write_release_yml(build_dir, out)
 
-              json = JSON.parse(IO.read(File.join(web_dir, "project.json")))
-              expect(json).to have_key("dependencies")
-              expect(json["dependencies"]).to have_key("Nowin.vNext")
-              expect(json["dependencies"]["Nowin.vNext"]).to match("1.0.0-*")
+              json = JSON.parse(IO.read(File.join(web_dir, 'project.json')))
+              expect(json).to have_key('dependencies')
+              expect(json['dependencies']).to have_key('Nowin.vNext')
+              expect(json['dependencies']['Nowin.vNext']).to match('1.0.0-*')
             end
           end
         end
       end
 
-      context "when there are multiple directories with a project.json file" do
+      context 'when there are multiple directories with a project.json file' do
         let(:web_dir) do
-          File.join(buildDir, "foo-cfweb").tap { |f| Dir.mkdir(f) }
+          File.join(build_dir, 'foo-cfweb').tap { |f| Dir.mkdir(f) }
         end
 
         let(:other_dir) do
-          File.join(buildDir, "bar").tap { |f| Dir.mkdir(f) }
+          File.join(build_dir, 'bar').tap { |f| Dir.mkdir(f) }
         end
 
-        context "and one contains a cf-web command" do
+        context 'and one contains a cf-web command' do
           before do
-            File.open(File.join(other_dir, "project.json"), 'w') do |f|
+            File.open(File.join(other_dir, 'project.json'), 'w') do |f|
               f.write '{ "commands": { "web": "whatever" } }'
             end
 
-            File.open(File.join(web_dir, "project.json"), 'w') do |f|
+            File.open(File.join(web_dir, 'project.json'), 'w') do |f|
               f.write '{ "commands": { "cf-web": "whatever" } }'
             end
           end
 
-          it "changes directory to that directory" do
-            expect(web_process).to match("cd foo-cfweb;")
+          it 'changes directory to that directory' do
+            expect(web_process).to match('cd foo-cfweb;')
           end
 
           it "runs 'dnx . cf-web'" do
-            expect(web_process).to match("dnx . cf-web")
+            expect(web_process).to match('dnx . cf-web')
           end
         end
 
-        context "and one contains a web command" do
+        context 'and one contains a web command' do
           before do
-            File.open(File.join(other_dir, "project.json"), 'w') do |f|
+            File.open(File.join(other_dir, 'project.json'), 'w') do |f|
               f.write '{ "commands": { "something": "whatever" } }'
             end
 
-            File.open(File.join(web_dir, "project.json"), 'w') do |f|
+            File.open(File.join(web_dir, 'project.json'), 'w') do |f|
               f.write '{ "commands": { "web": "whatever" } }'
             end
           end
 
-          it "changes directory to that directory" do
-            expect(web_process).to match("cd foo-cfweb;")
+          it 'changes directory to that directory' do
+            expect(web_process).to match('cd foo-cfweb;')
           end
 
           it "runs 'dnx . cf-web'" do
-            expect(web_process).to match("dnx . cf-web")
+            expect(web_process).to match('dnx . cf-web')
           end
         end
 
-        context "and one is Nowin.vNext" do
+        context 'and one is Nowin.vNext' do
           let(:nowin_dir) do
-            File.join(buildDir, "src", "Nowin.vNext").tap { |f| FileUtils.mkdir_p(f) }
+            File.join(build_dir, 'src', 'Nowin.vNext').tap { |f| FileUtils.mkdir_p(f) }
           end
 
           before do
-            File.open(File.join(nowin_dir, "project.json"), 'w') do |f|
+            File.open(File.join(nowin_dir, 'project.json'), 'w') do |f|
               f.write '{ "commands": { "web": "whatever" } }'
             end
 
-            File.open(File.join(web_dir, "project.json"), 'w') do |f|
+            File.open(File.join(web_dir, 'project.json'), 'w') do |f|
               f.write '{ "commands": { "whatever": "whatever" } }'
             end
           end
 
-          it "changes directory to the other directory" do
-            expect(web_process).to match("cd foo-cfweb;")
+          it 'changes directory to the other directory' do
+            expect(web_process).to match('cd foo-cfweb;')
           end
 
           it "runs 'dnx . cf-web'" do
-            expect(web_process).to match("dnx . cf-web")
+            expect(web_process).to match('dnx . cf-web')
           end
         end
       end

--- a/spec/buildpack/copier_spec.rb
+++ b/spec/buildpack/copier_spec.rb
@@ -16,7 +16,7 @@
 
 require 'rspec'
 require 'tmpdir'
-require_relative "../../lib/buildpack.rb"
+require_relative '../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::Copier do
   let(:src) do
@@ -28,35 +28,35 @@ describe AspNet5Buildpack::Copier do
   end
 
   let!(:file1) do
-    File.join(src, "file1").tap do |f|
-      File.open(f, 'w') { |w| w.write("something") }
+    File.join(src, 'file1').tap do |f|
+      File.open(f, 'w') { |w| w.write('something') }
     end
   end
 
   let!(:dir1) do
-    File.join(src, "dir1").tap do |d|
+    File.join(src, 'dir1').tap do |d|
       Dir.mkdir(d)
     end
   end
 
   let!(:one_level_deep) do
-    File.join(dir1, "one_level_deep").tap do |f|
-      File.open(f, 'w') { |w| w.write("something") }
+    File.join(dir1, 'one_level_deep').tap do |f|
+      File.open(f, 'w') { |w| w.write('something') }
     end
   end
 
   let(:out) do
-    double(:out, :print => nil)
+    double(:out, print: nil)
   end
 
-  it "copies all files from source to destination" do
+  it 'copies all files from source to destination' do
     subject.cp(src, dest, out)
-    expect(Dir[File.join(dest, "**/*")]).to include(
+    expect(Dir[File.join(dest, '**/*')]).to include(
       File.join(dest, File.basename(src), File.basename(file1)),
-      File.join(dest, File.basename(src), "dir1", File.basename(one_level_deep)))
+      File.join(dest, File.basename(src), 'dir1', File.basename(one_level_deep)))
   end
 
-  it "prints the number of files copied and the src/destination" do
+  it 'prints the number of files copied and the src/destination' do
     expect(out).to receive(:print).with("Copied 4 files from #{src} to #{dest}")
     subject.cp(src, dest, out)
   end

--- a/spec/buildpack/detect_spec.rb
+++ b/spec/buildpack/detect_spec.rb
@@ -14,28 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require "tmpdir"
-require_relative "../../lib/buildpack.rb"
+require 'rspec'
+require 'tmpdir'
+require_relative '../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::Detecter do
   let(:dir) do
     Dir.mktmpdir
   end
 
-  describe "detect" do
-    context "when there is no NuGet.Config in the root directory" do
-      it "returns false" do
+  describe 'detect' do
+    context 'when there is no NuGet.Config in the root directory' do
+      it 'returns false' do
         expect(subject.detect(dir)).to be_falsey
       end
     end
 
-    context "when there is a NuGet.Config in the root directory" do
+    context 'when there is a NuGet.Config in the root directory' do
       before do
-        File.open(File.join(dir, "NuGet.Config"), 'w') { |f| f.write("a") }
+        File.open(File.join(dir, 'NuGet.Config'), 'w') { |f| f.write('a') }
       end
 
-      it "returns true" do
+      it 'returns true' do
         expect(subject.detect(dir)).to be_truthy
       end
     end

--- a/spec/buildpack/shell_spec.rb
+++ b/spec/buildpack/shell_spec.rb
@@ -14,40 +14,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require_relative "../../lib/buildpack.rb"
+require 'rspec'
+require_relative '../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::Shell do
   let(:out) do
     double(:out)
   end
 
-  it "executes a command and returns the output" do
-    expect(out).to receive(:print).with("foo")
-    subject.exec("echo foo", out)
+  it 'executes a command and returns the output' do
+    expect(out).to receive(:print).with('foo')
+    subject.exec('echo foo', out)
   end
 
-  it "executes a command and returns the stderr output" do
-    expect(out).to receive(:print).with("foo")
-    subject.exec("echo foo 1>&2", out)
+  it 'executes a command and returns the stderr output' do
+    expect(out).to receive(:print).with('foo')
+    subject.exec('echo foo 1>&2', out)
   end
 
-  it "raises an exception containing the exit code if the command fails" do
-    expect { subject.exec("exit 12", out) }.to raise_error(/12/)
+  it 'raises an exception containing the exit code if the command fails' do
+    expect { subject.exec('exit 12', out) }.to raise_error(/12/)
   end
 
-  context "setting environment variables" do
-    it "appends an environment variable to future calls" do
-      expect(out).to receive(:print).with("BAR")
+  context 'setting environment variables' do
+    it 'appends an environment variable to future calls' do
+      expect(out).to receive(:print).with('BAR')
 
-      subject.env["FOO"] = "BAR"
-      subject.exec("echo $FOO", out)
+      subject.env['FOO'] = 'BAR'
+      subject.exec('echo $FOO', out)
     end
 
-    it "adds to the process path" do
+    it 'adds to the process path' do
       expect(out).to receive(:print).with(match(/mono/))
-      subject.path << "mono"
-      subject.exec("echo $PATH", out)
+      subject.path << 'mono'
+      subject.exec('echo $PATH', out)
     end
   end
 end

--- a/spec/buildpack/version_spec.rb
+++ b/spec/buildpack/version_spec.rb
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 require 'rspec'
-require_relative "../../lib/buildpack.rb"
+require_relative '../../lib/buildpack.rb'
 
 describe AspNet5Buildpack::BuildpackVersion do
-  it "can read the buildpack version from the VERSION file" do
+  it 'can read the buildpack version from the VERSION file' do
     expect(subject.version).not_to be_nil
   end
 end

--- a/spec/out_spec.rb
+++ b/spec/out_spec.rb
@@ -14,47 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec"
-require_relative "../lib/buildpack.rb"
+require 'rspec'
+require_relative '../lib/buildpack.rb'
 
 describe AspNet5Buildpack::Out do
-  describe "#step" do
-    it "prints step title with 6-character arrow" do
+  describe '#step' do
+    it 'prints step title with 6-character arrow' do
       expect($stdout).to receive(:puts).with("-----> foo\n")
-      subject.step("foo")
+      subject.step('foo')
     end
   end
 
-  describe "#warn" do
-    it "prints a big warning message surrounded by asterixes" do
-      expect($stdout).to receive(:puts).with("\n"+
+  describe '#warn' do
+    it 'prints a big warning message surrounded by asterixes' do
+      expect($stdout).to receive(:puts).with("\n" +
        "  ************************************************************************\n" +
        "  * WARNING: xyz abc 123 should wrap blah blah blah foo bar baz bing bo  *\n" +
        "  *          o. this is the first message of line 2.                     *\n" +
        "  ************************************************************************\n" +
        ".\n")
-      subject.warn("xyz abc 123 should wrap blah blah blah foo bar baz bing boo. this is the first message of line 2.")
+      subject.warn('xyz abc 123 should wrap blah blah blah foo bar baz bing boo. this is the first message of line 2.')
     end
   end
 
-  describe "#fail" do
+  describe '#fail' do
     it "prints failure message indented with the word 'FAILED'" do
       expect($stdout).to receive(:puts).with("       FAILED: foo\n")
-      subject.fail("foo")
+      subject.fail('foo')
     end
   end
 
-  describe "#succeed" do
-    it "prints OK indented" do
+  describe '#succeed' do
+    it 'prints OK indented' do
       expect($stdout).to receive(:puts).with("       OK\n")
       subject.succeed
     end
   end
 
-  describe "#print" do
-    it "prints message indented" do
+  describe '#print' do
+    it 'prints message indented' do
       expect($stdout).to receive(:puts).with("       foo\n")
-      subject.print("foo")
+      subject.print('foo')
     end
   end
 end


### PR DESCRIPTION
Mostly just changing double quotes to single quotes, but also fixed some spacing and old Ruby 1.8 hash syntax.