### PR TITLE
cleanup start command

### DIFF
--- a/lib/buildpack/compile/release_yml_writer.rb
+++ b/lib/buildpack/compile/release_yml_writer.rb
@@ -47,7 +47,7 @@ module AspNet5Buildpack
         f.write <<EOT
 ---
 default_process_types:
-  web: sleep 999999 | dnx --project #{web_dir} #{CFWEB_CMD} --server.urls http://${VCAP_APP_HOST}:${PORT}
+  web: dnx --project #{web_dir} #{CFWEB_CMD} --server.urls http://0.0.0.0:${PORT}
 EOT
       end
     end


### PR DESCRIPTION
App aspnet5-start was started using this command *`dnx --project src/dotnetstarter kestrel --server.urls http://0.0.0.0:${PORT}`*

Showing health and status for app aspnet5-start in ...
OK

requested state: started