### PR TITLE
clean up staging output

### DIFF
--- a/lib/buildpack/compile/compiler.rb
+++ b/lib/buildpack/compile/compiler.rb
@@ -26,8 +26,6 @@ require 'pathname'
 
 module AspNet5Buildpack
   class Compiler
-    WARNING_MESSAGE = 'This is an experimental buildpack. It is not supported.   Do not expect it to work reliably. Please, do not         contact support about issues with this buildpack.'.freeze
-
     def initialize(build_dir, cache_dir, libuv_binary, libunwind_binary, dnvm_installer, dnx_installer, dnu, copier, out)
       @build_dir = build_dir
       @cache_dir = cache_dir
@@ -43,7 +41,6 @@ module AspNet5Buildpack
     def compile
       puts "ASP.NET 5 buildpack version: #{BuildpackVersion.new.version}\n"
       puts "ASP.NET 5 buildpack starting compile\n"
-      out.warn(WARNING_MESSAGE) unless WARNING_MESSAGE.nil?
       step('Restoring files from buildpack cache', method(:restore_cache))
       step('Extracting libuv', method(:extract_libuv))
       step('Extracting libunwind', method(:extract_libunwind))
@@ -55,9 +52,6 @@ module AspNet5Buildpack
       return true
     rescue StepFailedError => e
       out.fail(e.message)
-      puts ".\n"
-      out.warn(WARNING_MESSAGE)
-      sleep 2 # otherwise the warning message gets lost and you have to do logs --recent to see it
       return false
     end
 

--- a/lib/buildpack/compile/dnu.rb
+++ b/lib/buildpack/compile/dnu.rb
@@ -26,7 +26,7 @@ module AspNet5Buildpack
       @shell.env['HOME'] = dir
       @shell.env['LD_LIBRARY_PATH'] = "$LD_LIBRARY_PATH:#{dir}/libunwind/lib"
       project_list = AppDir.new(dir).with_project_json.join(' ')
-      cmd = "bash -c 'source #{dir}/.dnx/dnvm/dnvm.sh; dnvm use default; cd #{dir}; dnu restore #{project_list}'"
+      cmd = "bash -c 'source #{dir}/.dnx/dnvm/dnvm.sh; dnvm use default; cd #{dir}; dnu restore --quiet #{project_list}'"
       @shell.exec(cmd, out)
     end
   end

--- a/spec/buildpack/compile/compile_spec.rb
+++ b/spec/buildpack/compile/compile_spec.rb
@@ -43,11 +43,6 @@ describe AspNet5Buildpack::Compiler do
     end
   end
 
-  it 'prints experimental warning message' do
-    expect(out).to receive(:warn).with(match('experimental'))
-    compiler.compile
-  end
-
   shared_examples 'step' do |expected_message, step|
     let(:step_out) do
       double(:step_out, succeed: nil).tap do |step_out|
@@ -73,7 +68,6 @@ describe AspNet5Buildpack::Compiler do
         allow(out).to receive(:warn)
         expect(step_out).to receive(:fail).with(match(/fishfinger in the warp core/))
         expect(out).to receive(:fail).with(match(/#{expected_message} failed, fishfinger in the warp core/))
-        expect(out).to receive(:warn).with(match('experimental'))
         expect { compiler.compile }.not_to raise_error
       end
     end


### PR DESCRIPTION
With the switch to .NET Core the "dnu restore" output was getting too long and with the runtime stabilizing I don't think the experimental warning message is necessary (or relevant to the open source community).