### PR TITLE
Allow usage of a web command to start the Kestrel webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cf push my_app -b https://github.com/cloudfoundry-community/asp.net5-buildpack.g
 
 This buildpack will be used if there are one or more `project.json` files in the pushed application. 
 
-Also make sure the application includes a `kestrel` command and the corresponding dependency because the buildpack will use [Kestrel][] to run the application.
+Also make sure the application includes a `kestrel` or a `web` command and the corresponding Microsoft.AspNet.Server.Kestrel dependency because the buildpack will use [Kestrel][] to run the application.
 
 Use a `global.json` file to specify the desired DNX version if different than the latest stable beta release. Use a `NuGet.Config` file to specify non-default package sources.
 

--- a/spec/buildpack/release/releaser_spec.rb
+++ b/spec/buildpack/release/releaser_spec.rb
@@ -74,17 +74,25 @@ describe AspNet5Buildpack::Releaser do
         expect(web_process).to match('dnx --project foo kestrel')
       end
 
-      context 'project.json does not contain a kestrel command' do
-        let(:project_json) { '{"commands": {"web": "whatever"}}' }
+      context 'project.json does not contain a kestrel or web command' do
+        let(:project_json) { '{"commands": {"notkestrelorweb": "whatever"}}' }
 
         it 'raises an error because start command will not work' do
-          expect { subject.release(build_dir) }.to raise_error(/No kestrel command found in foo/)
+          expect { subject.release(build_dir) }.to raise_error(/No kestrel or web command found in foo/)
         end
       end
 
       context 'project.json contains a kestrel command' do
         it "runs 'dnx kestrel' for project" do
           expect(web_process).to match('dnx --project foo kestrel')
+        end
+      end
+
+      context 'project.json contains a web command' do
+        let(:project_json) { '{"commands": {"web": "whatever"}}' }
+
+        it "runs 'dnx web' for project" do
+          expect(web_process).to match('dnx --project foo web')
         end
       end
 


### PR DESCRIPTION
Supports using a "web" command in addition to "kestrel" to support changes in the way that Yeoman generates project.json files now.