### PR TITLE
Rake should run Rubocop too

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 AllCops:
   Exclude:
     - compile-extensions/**/*
+    - vendor/**/*
 Documentation:
   Enabled: false
 LineLength:

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = Dir.glob('spec/**/*_spec.rb')
 end
 
-task default: [:spec]
+task default: [:rubocop, :spec]


### PR DESCRIPTION
Rubocop wasn't being run with the rake command in Travis CI.