### PR TITLE
Add support for self-contained apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With the introduction of support for the Dotnet CLI in buildpack version 0.8, ap
 cf push my_app -b https://github.com/cloudfoundry-community/asp.net5-buildpack.git#dnx
 ```
 
-Keep in mind that this support provided to allow users time to update their apps to use the Dotnet CLI, and you should switch to using the main branch of the buildpack (using the command further above) as soon as possible.
+Keep in mind that this support is provided only to allow users to take some time to update their applications to use the Dotnet CLI, and you should switch to using the main branch of the buildpack (using the command further above) as soon as possible.
 
 ## Using samples from the cli-samples repository
 
@@ -67,11 +67,17 @@ public static void Main(string[] args)
 
 The binaries in `manifest.yml` can be cached with the buildpack.
 
-Applications can be pushed with their other dependencies after "publishing" the application like `dotnet publish`. Then push from the `bin/<Debug|Release>/<framework>/publish` directory.
+Applications can be pushed with their other dependencies after "publishing" the application like `dotnet publish -r ubuntu.14.04-x64`.  Then push from the `bin/<Debug|Release>/<framework>/<runtime>/publish` directory.
+
+For this publish command to work, you will need to make some changes to your application code to ensure that the dotnet cli publishes it as a self-contained application rather than a portable application.
+
+See [Types of portability in .Net Core][] for more information on how to make the required changes to publish your application as a self-contained application.
+
+Also note that if you are using a `manifest.yml` file in your application, you can [specify the path][] in your manifest.yml to point to the publish output folder so that you don't have to be in that folder to push the application to Cloud Foundry.
 
 ## Building
 
-These steps only apply to admins who wish to install the buildpack into their Cloud Foundry deployment. They are meant to be run in a Linux shell and assume that git, Ruby, and the bundler gem are already installed.  
+These steps only apply to admins who wish to install the buildpack into their Cloud Foundry deployment. They are meant to be run in a Linux shell and assume that git, Ruby, and the bundler gem are already installed.
 
 1. Make sure you have fetched submodules
 
@@ -118,3 +124,5 @@ Open an issue on this project.
 [Hello World sample]: https://github.com/IBM-Bluemix/asp.net5-helloworld
 [RC2]: https://github.com/aspnet/Home/releases/tag/1.0.0-rc2-final
 [Kestrel]: https://github.com/aspnet/KestrelHttpServer
+[Types of portability in .Net Core]: http://dotnet.github.io/docs/core-concepts/app-types.html
+[specify the path]: http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#path

--- a/lib/buildpack/compile/compiler.rb
+++ b/lib/buildpack/compile/compiler.rb
@@ -39,8 +39,8 @@ module AspNetCoreBuildpack
       puts "ASP.NET Core buildpack starting compile\n"
       step('Restoring files from buildpack cache', method(:restore_cache))
       step('Extracting libunwind', method(:extract_libunwind))
-      step('Installing Dotnet CLI', method(:install_dotnet))
-      step('Restoring dependencies with Dotnet CLI', method(:restore_dependencies))
+      step('Installing Dotnet CLI', method(:install_dotnet)) if dotnet_installer.should_install(build_dir)
+      step('Restoring dependencies with Dotnet CLI', method(:restore_dependencies)) if dotnet_installer.should_install(build_dir)
       step('Saving to buildpack cache', method(:save_cache))
       puts "ASP.NET Core buildpack is done creating the droplet\n"
       return true
@@ -61,11 +61,11 @@ module AspNetCoreBuildpack
     end
 
     def install_dotnet(out)
-      dotnet_installer.install(build_dir, out) unless File.exist? File.join(build_dir, 'approot', 'runtimes')
+      dotnet_installer.install(build_dir, out)
     end
 
     def restore_dependencies(out)
-      dotnet.restore(build_dir, out) unless File.exist? File.join(build_dir, 'approot', 'packages')
+      dotnet.restore(build_dir, out)
     end
 
     def save_cache(out)

--- a/lib/buildpack/compile/dotnet_installer.rb
+++ b/lib/buildpack/compile/dotnet_installer.rb
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative '../app_dir'
+
 module AspNetCoreBuildpack
   class DotnetInstaller
     def initialize(shell)
@@ -25,6 +27,14 @@ module AspNetCoreBuildpack
       install_script_url = 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh'
       cmd = "bash -c 'DOTNET_INSTALL_SKIP_PREREQS=1 source <(curl -sSL #{install_script_url})'"
       @shell.exec(cmd, out)
+    end
+
+    def should_install(dir)
+      published_project = AppDir.new(dir).published_project
+      if published_project && File.exist?(File.join(dir, published_project))
+        return false
+      end
+      true
     end
   end
 end

--- a/spec/buildpack/compile/compile_spec.rb
+++ b/spec/buildpack/compile/compile_spec.rb
@@ -30,7 +30,7 @@ describe AspNetCoreBuildpack::Compiler do
 
   let(:libunwind_binary) { double(:libunwind_binary, extract: nil) }
   let(:copier) { double(:copier, cp: nil) }
-  let(:dotnet_installer) { double(:dotnet_installer, install: nil) }
+  let(:dotnet_installer) { double(:dotnet_installer, install: nil, should_install: true) }
   let(:dotnet) { double(:dotnet, restore: nil) }
   let(:build_dir) { Dir.mktmpdir }
   let(:cache_dir) { Dir.mktmpdir }
@@ -114,6 +114,14 @@ describe AspNetCoreBuildpack::Compiler do
         expect(dotnet_installer).to receive(:install).with(build_dir, anything)
         compiler.compile
       end
+
+      context 'when the app was published' do
+        it 'skips installing Dotnet CLI' do
+          allow(dotnet_installer).to receive(:should_install).and_return(false)
+          expect(dotnet_installer).not_to receive(:install).with(build_dir, anything)
+          compiler.compile
+        end
+      end
     end
 
     describe 'Restoring dependencies with Dotnet CLI' do
@@ -124,12 +132,9 @@ describe AspNetCoreBuildpack::Compiler do
         compiler.compile
       end
 
-      context 'when the app was published with NuGet packages' do
-        before do
-          FileUtils.mkdir_p(File.join(build_dir, 'approot', 'packages'))
-        end
-
+      context 'when the app was published' do
         it 'skips running dotnet restore' do
+          allow(dotnet_installer).to receive(:should_install).and_return(false)
           expect(dotnet).not_to receive(:restore)
           compiler.compile
         end

--- a/spec/buildpack/release/releaser_spec.rb
+++ b/spec/buildpack/release/releaser_spec.rb
@@ -40,12 +40,28 @@ describe AspNetCoreBuildpack::Releaser do
         File.open(File.join(build_dir, 'proj1.runtimeconfig.json'), 'w') { |f| f.write('a') }
       end
 
-      it 'does not raise an error because project.json is not required' do
-        expect { subject.release(build_dir) }.not_to raise_error
+      context 'project is self-contained' do
+        before do
+          File.open(File.join(build_dir, 'proj1'), 'w') { |f| f.write('a') }
+        end
+
+        it 'does not raise an error because project.json is not required' do
+          expect { subject.release(build_dir) }.not_to raise_error
+        end
+
+        it 'runs native binary for the project which has a runtimeconfig.json file' do
+          expect(web_process).to match('proj1')
+        end
       end
 
-      it 'runs dotnet <dllname> for the project which has a runtimeconfig.json file' do
-        expect(web_process).to match('dotnet proj1.dll')
+      context 'project is a portable project' do
+        before do
+          File.open(File.join(build_dir, 'proj1.dll'), 'w') { |f| f.write('a') }
+        end
+
+        it 'runs dotnet <dllname> for the project which has a runtimeconfig.json file' do
+          expect(web_process).to match('dotnet proj1.dll')
+        end
       end
     end
 


### PR DESCRIPTION
v0.7 release of the buildpack supported apps which were published to include the runtime, but this functionality was lost in the v0.8 release.  This commit adds support for apps published as a self-contained app including the runtime itself, as well as support for apps published as a portable app which does not contain the runtime.