### PR TITLE
Specify dotnet CLI version in global.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cf push my_app -b https://github.com/cloudfoundry-community/asp.net5-buildpack.g
 
 This buildpack will be used if there are one or more `project.json` files in the pushed application, or if the application is pushed from the output directory of the `dotnet publish` command. 
 
-Use a `NuGet.Config` file to specify non-default package sources.
+Use a `global.json` file to specify the desired .Net CLI version if different than the latest stable beta release.  Use a `NuGet.Config` file to specify non-default package sources.
 
 For a basic example see this [Hello World sample][].
 

--- a/lib/buildpack/compile/dotnet_installer.rb
+++ b/lib/buildpack/compile/dotnet_installer.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative '../app_dir'
+require_relative 'dotnet_version'
 
 module AspNetCoreBuildpack
   class DotnetInstaller
@@ -24,8 +25,9 @@ module AspNetCoreBuildpack
 
     def install(dir, out)
       @shell.env['HOME'] = dir
+      version = DotnetVersion.new.version(dir, out)
       install_script_url = 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh'
-      cmd = "bash -c 'DOTNET_INSTALL_SKIP_PREREQS=1 source <(curl -sSL #{install_script_url})'"
+      cmd = "bash -c 'curl -OsSL #{install_script_url}; chmod 755 dotnet-install.sh; DOTNET_INSTALL_SKIP_PREREQS=1 ./dotnet-install.sh -v #{version}'"
       @shell.exec(cmd, out)
     end
 

--- a/lib/buildpack/compile/dotnet_version.rb
+++ b/lib/buildpack/compile/dotnet_version.rb
@@ -1,0 +1,41 @@
+# Encoding: utf-8
+# ASP.NET Core Buildpack
+# Copyright 2014-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+
+module AspNetCoreBuildpack
+  class DotnetVersion
+    DOTNET_VERSION_FILE_NAME = 'global.json'.freeze
+    DEFAULT_DOTNET_VERSION = 'latest'.freeze
+
+    def version(dir, out)
+      dotnet_version = DEFAULT_DOTNET_VERSION
+      version_file = File.expand_path(File.join(dir, DOTNET_VERSION_FILE_NAME))
+      if File.exist?(version_file)
+        begin
+          global_props = JSON.parse(File.read(version_file, encoding: 'bom|utf-8'))
+          if global_props.key?('sdk')
+            sdk = global_props['sdk']
+            dotnet_version = sdk['version'] if sdk.key?('version')
+          end
+        rescue
+          out.warn("File #{version_file} is not valid JSON")
+        end
+      end
+      dotnet_version
+    end
+  end
+end

--- a/spec/buildpack/compile/dotnet_installer_spec.rb
+++ b/spec/buildpack/compile/dotnet_installer_spec.rb
@@ -29,7 +29,7 @@ describe AspNetCoreBuildpack::DotnetInstaller do
     end
 
     it 'installs Dotnet CLI' do
-      cmd = %r{(bash -c 'DOTNET_INSTALL_SKIP_PREREQS=1 source <\(curl -sSL https:\/\/.*\/dotnet-install.sh\)')}
+      cmd = %r{(bash -c 'curl -OsSL https:\/\/.*\/dotnet-install.sh; .* DOTNET_INSTALL_SKIP_PREREQS=1 \.\/dotnet-install.sh -v latest')}
       expect(shell).to receive(:exec).with(match(cmd), out)
       installer.install('passed-directory', out)
     end

--- a/spec/buildpack/compile/dotnet_version_spec.rb
+++ b/spec/buildpack/compile/dotnet_version_spec.rb
@@ -1,0 +1,77 @@
+# Encoding: utf-8
+# ASP.NET Core Buildpack
+# Copyright 2014-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rspec'
+require 'tmpdir'
+require_relative '../../../lib/buildpack.rb'
+
+describe AspNetCoreBuildpack::DotnetVersion do
+  let(:out) { double(:out) }
+  let(:dir) { Dir.mktmpdir }
+
+  describe '#version' do
+    context 'global.json does not exist' do
+      it 'resolves to the latest version' do
+        expect(subject.version(dir, out)).to eq('latest')
+      end
+    end
+
+    context 'global.json exists' do
+      before do
+        json = '{ "sdk": { "version": "1.0.0-beta1" } }'
+        IO.write(File.join(dir, 'global.json'), json)
+      end
+
+      it 'resolves to the specified version' do
+        expect(subject.version(dir, out)).to eq('1.0.0-beta1')
+      end
+    end
+
+    context 'global.json exists with a BOM from Visual Studio in it' do
+      before do
+        json = "\uFEFF{ \"sdk\": { \"version\": \"1.0.0-beta1\" } }"
+        IO.write(File.join(dir, 'global.json'), json)
+      end
+
+      it 'resolves to the specified version' do
+        expect(subject.version(dir, out)).to eq('1.0.0-beta1')
+      end
+    end
+
+    context 'invalid global.json exists' do
+      before do
+        json = '"version": "1.0.0-beta1"'
+        IO.write(File.join(dir, 'global.json'), json)
+      end
+
+      it 'warns and resolves to the latest version' do
+        expect(out).to receive(:warn).with("File #{dir}/global.json is not valid JSON")
+        expect(subject.version(dir, out)).to eq('latest')
+      end
+    end
+
+    context 'global.json exists but does not include a version' do
+      before do
+        json = '{ "projects": [ "src", "test" ] }'
+        IO.write(File.join(dir, 'global.json'), json)
+      end
+
+      it 'resolves to the latest version' do
+        expect(subject.version(dir, out)).to eq('latest')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change will let users set the version of the .Net CLI that gets installed by setting the version value for the sdk in the global.json file, just like they did in RC1 with dnx.